### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: '/alura-newsletter/',
   server: {
-    host: true, 
+    host: true,
     port: 5173,
   },
 })


### PR DESCRIPTION
## Summary
- set the Vite base path to /alura-newsletter/ so built assets resolve correctly on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68def2ef66808323bc223ffd4240f792