### PR TITLE
Fix article image resolution to use relative paths

### DIFF
--- a/articles.json
+++ b/articles.json
@@ -29,7 +29,7 @@
       "text": [
         "No último episódio do #HipstersPontoTube, Diogo Pires e Paulo Silveira conversaram sobre a importância do portfólio e quais são as dicas para criar essa ferramenta essencial para todos os níveis de profissionais. Eles também dão algumas dicas de carreira, respondendo perguntas como “quando é o momento certo de me aplicar nas vagas?”."
       ],
-      "image": "/example.jpeg",
+      "image": "example.jpeg",
       "alt": "Screenshot do Youtube com o episódio do podcast rodando",
       "tags": ["carreira", "podcast"]
     }

--- a/src/components/Article/Article.jsx
+++ b/src/components/Article/Article.jsx
@@ -1,4 +1,6 @@
-const Article = ({ title, text, tags, image, alt}) => {
+const Article = ({ title, text, tags, image, alt }) => {
+    const resolvedImage = image ? new URL(image, import.meta.env.BASE_URL).href : null;
+
     return <div className="alura-card">
         <h3 className="text-xl text-alura-200 dark:text-gray-200 font-bold">{title}</h3>
         <div className="w-full flex-row justify-end gap-2 pr-5 hidden sm:flex">
@@ -11,8 +13,8 @@ const Article = ({ title, text, tags, image, alt}) => {
                 text.map((content, index) => <p key={index} className="text-alura-200 dark:text-gray-400 line-clamp-4 sm:line-clamp-none">{content}</p>)
             }
         </div>
-        { image && <img className="sm:p-4" src={image} />}
-        { image && alt && <span className="sr-only">{alt}</span> }
+        { resolvedImage && <img className="sm:p-4" src={resolvedImage} /> }
+        { resolvedImage && alt && <span className="sr-only">{alt}</span> }
     </div>
 }
 


### PR DESCRIPTION
## Summary
- update the final article entry to reference the newsletter image via a relative path
- resolve article images against the Vite base URL before rendering to ensure they load in production

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68def6a493d08323bc6d385ebeb786f7